### PR TITLE
Update installation_cheat.sh

### DIFF
--- a/installation_cheat.sh
+++ b/installation_cheat.sh
@@ -12,7 +12,7 @@ clear
 function install_utils
 {
         apt update && apt upgrade -y
-        apt install vim sudo rsync git net-tools mlocate htop screen figlet curl -y
+        apt install vim sudo rsync git net-tools mlocate htop screen figlet curl apt-transport-https -y
 }
 
 function install_cheat


### PR DESCRIPTION
Cela permet d'utiliser le protocole https avec wget (et d'autre binaire).
J'ai ce problème sur mes distro debian dans se packet le wget du cheatsheet sur github pose problème.